### PR TITLE
Check that the tilt setup is still working

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: check
+name: build
 
 on: [ push, pull_request ]
 

--- a/.github/workflows/tilt.yaml
+++ b/.github/workflows/tilt.yaml
@@ -1,0 +1,55 @@
+name: tilt
+
+on: [ push, pull_request ]
+
+jobs:
+  tilt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.18.0'
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 21
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - uses: azure/setup-kubectl@v3
+        with:
+          version: v1.28.4
+
+      - uses: azure/setup-helm@v3
+        with:
+          version: v3.4.0
+
+      - name: checkout git repo
+        uses: actions/checkout@v3
+
+      - name: Install k3d
+        run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+
+      - name: Install tilt
+        run: curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
+
+      - name: Create k3d cluster
+        run: k3d cluster create --config config/k3d/dev-cluster.yaml
+
+      - name: Run tilt
+        run: tilt ci
+
+      - name: Call Front-end Application
+        run: |
+          HTTP_STATUS_CODE=$(curl -LI -s -o /dev/null -w "%{http_code}" 127.0.0.1.nip.io:8081)
+          if [ ${HTTP_STATUS_CODE} -ne 200 ]; then
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# Idea
+![build](https://github.com/orltom/sandbox/actions/workflows/ci.yaml/badge.svg)
+![tilt](https://github.com/orltom/sandbox/actions/workflows/tilt.yaml/badge.svg)
+
+# Intention
 This project is a personal playground to learn about new technologies and concepts. 
 It intends to explore all facets of the application lifecycle, from development to operations.
+
+# Project Idea
+The software project idea is to develop a platform that randomly publishes jokes.
 
 ## Prerequisites
 * Install [golang](https://go.dev/doc/install)
@@ -11,19 +17,12 @@ It intends to explore all facets of the application lifecycle, from development 
 * Install [tilt](https://tilt.dev/)
 
 ## Development Setup
-Setup k3d cluster
 ```shell
+# create k8s cluster
 k3d cluster create --config config/k3d/dev-cluster.yaml
-```
 
-Build and deploy
-```shell
+# Build and deploy
 tilt up
-```
-
-Open browser 
-```shell
-http://127.0.0.1.nip.io/ui
 ```
 
 ## Contributing

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,6 +1,10 @@
-load('ext://cert_manager', 'deploy_cert_manager')
+update_settings(k8s_upsert_timeout_secs=120)
+
+ci_settings(timeout = '30m')
 
 analytics_settings(enable=False)
+
+load('ext://cert_manager', 'deploy_cert_manager')
 
 allow_k8s_contexts('default')
 


### PR DESCRIPTION
A GitHub workflow was created to check whether the Tilt setup is still working. Tilt is started in CI mode and if all k8s workloads are healthy. A request to the UI application will be executed to verify if it was successful.

fix #4 